### PR TITLE
Fix Hoatzin worldgen thread lock

### DIFF
--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/HoatzinEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/HoatzinEntity.java
@@ -72,11 +72,11 @@ public class HoatzinEntity extends ParrotEntity implements GeoEntity, FeedableEn
     }
 
     protected <E extends HoatzinEntity> PlayState idleAnimController(final AnimationState<E> state) {
-        if (state.isMoving() && isOnGround()) {
+        if (state.isMoving() && isBlockBelow()) {
             state.setAndContinue(WALKING_ANIM);
-        } else if (!isOnGround()) {
+        } else if (!isBlockBelow()) {
             state.setAndContinue(FLY_ANIM);
-        } else if (!state.isMoving() && isOnGround()) {
+        } else if (!state.isMoving() && isBlockBelow()) {
             state.setAndContinue(IDLE_ANIM);
         }
 
@@ -91,8 +91,7 @@ public class HoatzinEntity extends ParrotEntity implements GeoEntity, FeedableEn
                 .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.6f);
     }
 
-    @Override
-    public boolean isOnGround() {
+    public boolean isBlockBelow() {
         return !this.getWorld().getBlockState(getBlockPos().down()).isAir();
     }
 


### PR DESCRIPTION
Resolves the game locking up on the server thread when a Hoatzin attempts to spawn. Closes #1.

![image](https://github.com/user-attachments/assets/fe79dd7b-780d-4c8f-977e-e4105bd905bf)

This is caused by `isOnGround` being overridden, which is a method utilized by `writeNbt` during world generation to fetch its own internal state. The overridden version attempts to read the block below, however the chunk does not exist as it is still generating at this point, so it enters an infinite loop waiting for the thread to unlock and freezes the game.

Renaming the overridden method and its usages to something else solves the problem.
