### PR TITLE
Switch to biome tags for biome-based entity spawning.

### DIFF
--- a/src/main/java/cybercat5555/faunus/Faunus.java
+++ b/src/main/java/cybercat5555/faunus/Faunus.java
@@ -26,6 +26,7 @@ public class Faunus implements ModInitializer {
 
         configHandler();
         eventHandler();
+        SpawnHandler.removeSpawn();
         SpawnHandler.addSpawn();
     }
 

--- a/src/main/java/cybercat5555/faunus/common/config/MobSpawningConfig.java
+++ b/src/main/java/cybercat5555/faunus/common/config/MobSpawningConfig.java
@@ -7,41 +7,25 @@ import cybercat5555.faunus.util.SimpleConfig;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 public class MobSpawningConfig {
     public static SimpleConfig config;
     private static ConfigRegistry configRegistry;
 
     public static int ARAPAIMA_SPAWN_WEIGHT, ARAPAIMA_SPAWN_MIN_GROUP, ARAPAIMA_SPAWN_MAX_GROUP;
-    public static String[] ARAPAIMA_BIOME_TAG;
     public static int CAPUCHIN_SPAWN_WEIGHT, CAPUCHIN_SPAWN_MIN_GROUP, CAPUCHIN_SPAWN_MAX_GROUP;
-    public static String[] CAPUCHIN_BIOME_TAG;
     public static int CONSTRICTOR_SPAWN_WEIGHT, CONSTRICTOR_SPAWN_MIN_GROUP, CONSTRICTOR_SPAWN_MAX_GROUP;
-    public static String[] CONSTRICTOR_BIOME_TAG;
     public static int CRAYFISH_SPAWN_WEIGHT, CRAYFISH_SPAWN_MIN_GROUP, CRAYFISH_SPAWN_MAX_GROUP;
-    public static String[] CRAYFISH_BIOME_TAG;
     public static int HOATZIN_SPAWN_WEIGHT, HOATZIN_SPAWN_MIN_GROUP, HOATZIN_SPAWN_MAX_GROUP;
-    public static String[] HOATZIN_BIOME_TAG;
     public static int LEECH_SPAWN_WEIGHT, LEECH_SPAWN_MIN_GROUP, LEECH_SPAWN_MAX_GROUP;
-    public static String[] LEECH_BIOME_TAG;
     public static int PIRANHA_SPAWN_WEIGHT, PIRANHA_SPAWN_MIN_GROUP, PIRANHA_SPAWN_MAX_GROUP;
-    public static String[] PIRANHA_BIOME_TAG;
     public static int QUETZAL_SPAWN_WEIGHT, QUETZAL_SPAWN_MIN_GROUP, QUETZAL_SPAWN_MAX_GROUP;
-    public static String[] QUETZAL_BIOME_TAG;
     public static int SNAPPING_TURTLE_SPAWN_WEIGHT, SNAPPING_TURTLE_SPAWN_MIN_GROUP, SNAPPING_TURTLE_SPAWN_MAX_GROUP;
-    public static String[] SNAPPING_TURTLE_BIOME_TAG;
     public static int SONGBIRD_SPAWN_WEIGHT, SONGBIRD_SPAWN_MIN_GROUP, SONGBIRD_SPAWN_MAX_GROUP;
-    public static String[] SONGBIRD_BIOME_TAG;
     public static int TAPIR_SPAWN_WEIGHT, TAPIR_SPAWN_MIN_GROUP, TAPIR_SPAWN_MAX_GROUP;
-    public static String[] TAPIR_BIOME_TAG;
     public static int TARANTULA_SPAWN_WEIGHT, TARANTULA_SPAWN_MIN_GROUP, TARANTULA_SPAWN_MAX_GROUP;
-    public static String[] TARANTULA_BIOME_TAG;
     public static int YACARE_SPAWN_WEIGHT, YACARE_SPAWN_MIN_GROUP, YACARE_SPAWN_MAX_GROUP;
-    public static String[] YACARE_BIOME_TAG;
     public static int YACARE_MANEATER_SPAWN_WEIGHT, YACARE_MANEATER_MIN_GROUP, YACARE_MANEATER_MAX_GROUP;
-    public static String[] YACARE_MANEATER_BIOME_TAG;
 
 
     public static void init(Path configPath) {
@@ -60,169 +44,128 @@ public class MobSpawningConfig {
         configRegistry.addPairData(new Pair<>("arapaima_spawn_weight", 5), "Arapaima spawn weight");
         configRegistry.addPairData(new Pair<>("arapaima_spawn_min_group", 1), "Arapaima spawn min group");
         configRegistry.addPairData(new Pair<>("arapaima_spawn_max_group", 3), "Arapaima spawn max group");
-        configRegistry.addPairData(new Pair<>("arapaima_biome_tag", "[river, swamp, mangrove_swamp]"), "Arapaima biome tag");
 
         configRegistry.addComment("Capuchin");
         configRegistry.addPairData(new Pair<>("capuchin_spawn_weight", 5), "Capuchin spawn weight");
         configRegistry.addPairData(new Pair<>("capuchin_spawn_min_group", 1), "Capuchin spawn min group");
         configRegistry.addPairData(new Pair<>("capuchin_spawn_max_group", 3), "Capuchin spawn max group");
-        configRegistry.addPairData(new Pair<>("capuchin_biome_tag", "[jungle, bamboo_jungle, sparse_jungle]"), "Capuchin biome tag");
 
         configRegistry.addComment("Constrictor");
         configRegistry.addPairData(new Pair<>("constrictor_spawn_weight", 5), "Constrictor spawn weight");
         configRegistry.addPairData(new Pair<>("constrictor_spawn_min_group", 1), "Constrictor spawn min group");
         configRegistry.addPairData(new Pair<>("constrictor_spawn_max_group", 3), "Constrictor spawn max group");
-        configRegistry.addPairData(new Pair<>("constrictor_biome_tag", "[]"), "Constrictor biome tag");
 
         configRegistry.addComment("Crayfish");
         configRegistry.addPairData(new Pair<>("crayfish_spawn_weight", 5), "Crayfish spawn weight");
         configRegistry.addPairData(new Pair<>("crayfish_spawn_min_group", 1), "Crayfish spawn min group");
         configRegistry.addPairData(new Pair<>("crayfish_spawn_max_group", 3), "Crayfish spawn max group");
-        configRegistry.addPairData(new Pair<>("crayfish_biome_tag", "[swamp, mangrove_swamp]"), "Crayfish biome tag");
 
         configRegistry.addComment("Hoatzin");
         configRegistry.addPairData(new Pair<>("hoatzin_spawn_weight", 5), "Hoatzin spawn weight");
         configRegistry.addPairData(new Pair<>("hoatzin_spawn_min_group", 1), "Hoatzin spawn min group");
         configRegistry.addPairData(new Pair<>("hoatzin_spawn_max_group", 3), "Hoatzin spawn max group");
-        configRegistry.addPairData(new Pair<>("hoatzin_biome_tag", "[jungle, bamboo_jungle, sparse_jungle, mangrove_swamp]"), "Hoatzin biome tag");
 
         configRegistry.addComment("Leech");
         configRegistry.addPairData(new Pair<>("leech_spawn_weight", 5), "Leech spawn weight");
         configRegistry.addPairData(new Pair<>("leech_spawn_min_group", 1), "Leech spawn min group");
         configRegistry.addPairData(new Pair<>("leech_spawn_max_group", 3), "Leech spawn max group");
-        configRegistry.addPairData(new Pair<>("leech_biome_tag", "[swamp, mangrove_swamp]"), "Leech biome tag");
 
         configRegistry.addComment("Piranha");
         configRegistry.addPairData(new Pair<>("piranha_spawn_weight", 5), "Piranha spawn weight");
         configRegistry.addPairData(new Pair<>("piranha_spawn_min_group", 1), "Piranha spawn min group");
         configRegistry.addPairData(new Pair<>("piranha_spawn_max_group", 3), "Piranha spawn max group");
-        configRegistry.addPairData(new Pair<>("piranha_biome_tag", "[mangrove_swamp, jungle, bamboo_jungle, sparse_jungle]"), "Piranha biome tag");
 
         configRegistry.addComment("Quetzal");
         configRegistry.addPairData(new Pair<>("quetzal_spawn_weight", 5), "Quetzal spawn weight");
         configRegistry.addPairData(new Pair<>("quetzal_spawn_min_group", 1), "Quetzal spawn min group");
         configRegistry.addPairData(new Pair<>("quetzal_spawn_max_group", 3), "Quetzal spawn max group");
-        configRegistry.addPairData(new Pair<>("quetzal_biome_tag", "[jungle, bamboo_jungle, sparse_jungle]"), "Quetzal biome tag");
 
         configRegistry.addComment("Snapping Turtle");
         configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_weight", 5), "Snapping Turtle spawn weight");
         configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_min_group", 1), "Snapping Turtle spawn min group");
         configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_max_group", 3), "Snapping Turtle spawn max group");
-        configRegistry.addPairData(new Pair<>("snapping_turtle_biome_tag", "[swamp]"), "Snapping Turtle biome tag");
 
         configRegistry.addComment("Songbird");
         configRegistry.addPairData(new Pair<>("songbird_spawn_weight", 5), "Songbird spawn weight");
         configRegistry.addPairData(new Pair<>("songbird_spawn_min_group", 1), "Songbird spawn min group");
         configRegistry.addPairData(new Pair<>("songbird_spawn_max_group", 3), "Songbird spawn max group");
-        configRegistry.addPairData(new Pair<>("songbird_biome_tag", "[swamp, jungle, bamboo_jungle, sparse_jungle, mangrove_swamp]"), "Songbird biome tag");
 
         configRegistry.addComment("Tapir");
         configRegistry.addPairData(new Pair<>("tapir_spawn_weight", 5), "Tapir spawn weight");
         configRegistry.addPairData(new Pair<>("tapir_spawn_min_group", 1), "Tapir spawn min group");
         configRegistry.addPairData(new Pair<>("tapir_spawn_max_group", 3), "Tapir spawn max group");
-        configRegistry.addPairData(new Pair<>("tapir_biome_tag", "[jungle, bamboo_jungle, sparse_jungle]"), "Tapir biome tag");
 
         configRegistry.addComment("Tarantula");
         configRegistry.addPairData(new Pair<>("tarantula_spawn_weight", 5), "Tarantula spawn weight");
         configRegistry.addPairData(new Pair<>("tarantula_spawn_min_group", 1), "Tarantula spawn min group");
         configRegistry.addPairData(new Pair<>("tarantula_spawn_max_group", 3), "Tarantula spawn max group");
-        configRegistry.addPairData(new Pair<>("tarantula_biome_tag", "[]"), "Tarantula biome tag");
 
         configRegistry.addComment("Yacare");
         configRegistry.addPairData(new Pair<>("yacare_spawn_weight", 5), "Yacare spawn weight");
         configRegistry.addPairData(new Pair<>("yacare_spawn_min_group", 1), "Yacare spawn min group");
         configRegistry.addPairData(new Pair<>("yacare_spawn_max_group", 3), "Yacare spawn max group");
-        configRegistry.addPairData(new Pair<>("yacare_biome_tag", "[swamp]"), "Yacare biome tag");
 
         configRegistry.addComment("Yacare Maneater");
         configRegistry.addPairData(new Pair<>("yacare_maneater_spawn_weight", 5), "Yacare Maneater spawn weight");
         configRegistry.addPairData(new Pair<>("yacare_maneater_spawn_min_group", 1), "Yacare Maneater spawn min group");
         configRegistry.addPairData(new Pair<>("yacare_maneater_spawn_max_group", 3), "Yacare Maneater spawn max group");
-        configRegistry.addPairData(new Pair<>("yacare_maneater_biome_tag", "[swamp]"), "Yacare Maneater biome tag");
     }
 
     private static void assignConfig() {
         ARAPAIMA_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("arapaima_spawn_weight", "0"));
         ARAPAIMA_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("arapaima_spawn_min_group", "0"));
         ARAPAIMA_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("arapaima_spawn_max_group", "0"));
-        ARAPAIMA_BIOME_TAG = getBiomeTags(config.getOrDefault("arapaima_biome_tag", null));
 
         CAPUCHIN_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("capuchin_spawn_weight", "0"));
         CAPUCHIN_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("capuchin_spawn_min_group", "0"));
         CAPUCHIN_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("capuchin_spawn_max_group", "0"));
-        CAPUCHIN_BIOME_TAG = getBiomeTags(config.getOrDefault("capuchin_biome_tag", null));
 
         CONSTRICTOR_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("constrictor_spawn_weight", "0"));
         CONSTRICTOR_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("constrictor_spawn_min_group", "0"));
         CONSTRICTOR_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("constrictor_spawn_max_group", "0"));
-        CONSTRICTOR_BIOME_TAG = getBiomeTags(config.getOrDefault("constrictor_biome_tag", null));
 
         CRAYFISH_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("crayfish_spawn_weight", "0"));
         CRAYFISH_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("crayfish_spawn_min_group", "0"));
         CRAYFISH_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("crayfish_spawn_max_group", "0"));
-        CRAYFISH_BIOME_TAG = getBiomeTags(config.getOrDefault("crayfish_biome_tag", null));
 
         HOATZIN_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("hoatzin_spawn_weight", "0"));
         HOATZIN_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("hoatzin_spawn_min_group", "0"));
         HOATZIN_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("hoatzin_spawn_max_group", "0"));
-        HOATZIN_BIOME_TAG = getBiomeTags(config.getOrDefault("hoatzin_biome_tag", null));
 
         LEECH_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("leech_spawn_weight", "0"));
         LEECH_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("leech_spawn_min_group", "0"));
         LEECH_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("leech_spawn_max_group", "0"));
-        LEECH_BIOME_TAG = getBiomeTags(config.getOrDefault("leech_biome_tag", null));
 
         PIRANHA_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("piranha_spawn_weight", "0"));
         PIRANHA_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("piranha_spawn_min_group", "0"));
         PIRANHA_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("piranha_spawn_max_group", "0"));
-        PIRANHA_BIOME_TAG = getBiomeTags(config.getOrDefault("piranha_biome_tag", null));
 
         QUETZAL_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("quetzal_spawn_weight", "0"));
         QUETZAL_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("quetzal_spawn_min_group", "0"));
         QUETZAL_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("quetzal_spawn_max_group", "0"));
-        QUETZAL_BIOME_TAG = getBiomeTags(config.getOrDefault("quetzal_biome_tag", null));
 
         SNAPPING_TURTLE_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("snapping_turtle_spawn_weight", "0"));
         SNAPPING_TURTLE_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("snapping_turtle_spawn_min_group", "0"));
         SNAPPING_TURTLE_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("snapping_turtle_spawn_max_group", "0"));
-        SNAPPING_TURTLE_BIOME_TAG = getBiomeTags(config.getOrDefault("snapping_turtle_biome_tag", null));
 
         SONGBIRD_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("songbird_spawn_weight", "0"));
         SONGBIRD_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("songbird_spawn_min_group", "0"));
         SONGBIRD_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("songbird_spawn_max_group", "0"));
-        SONGBIRD_BIOME_TAG = getBiomeTags(config.getOrDefault("songbird_biome_tag", null));
 
         TAPIR_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("tapir_spawn_weight", "0"));
         TAPIR_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("tapir_spawn_min_group", "0"));
         TAPIR_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("tapir_spawn_max_group", "0"));
-        TAPIR_BIOME_TAG = getBiomeTags(config.getOrDefault("tapir_biome_tag", null));
 
         TARANTULA_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("tarantula_spawn_weight", "0"));
         TARANTULA_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("tarantula_spawn_min_group", "0"));
         TARANTULA_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("tarantula_spawn_max_group", "0"));
-        TARANTULA_BIOME_TAG = getBiomeTags(config.getOrDefault("tarantula_biome_tag", null));
 
         YACARE_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("yacare_spawn_weight", "0"));
         YACARE_SPAWN_MIN_GROUP = Integer.parseInt(config.getOrDefault("yacare_spawn_min_group", "0"));
         YACARE_SPAWN_MAX_GROUP = Integer.parseInt(config.getOrDefault("yacare_spawn_max_group", "0"));
-        YACARE_BIOME_TAG = getBiomeTags(config.getOrDefault("yacare_biome_tag", null));
 
         YACARE_MANEATER_SPAWN_WEIGHT = Integer.parseInt(config.getOrDefault("yacare_maneater_spawn_weight", "0"));
         YACARE_MANEATER_MIN_GROUP = Integer.parseInt(config.getOrDefault("yacare_maneater_spawn_min_group", "0"));
         YACARE_MANEATER_MAX_GROUP = Integer.parseInt(config.getOrDefault("yacare_maneater_spawn_max_group", "0"));
-        YACARE_MANEATER_BIOME_TAG = getBiomeTags(config.getOrDefault("yacare_maneater_biome_tag", null));
-    }
-
-    private static String[] getBiomeTags(String biomeTags) {
-        if (biomeTags == null || biomeTags.isEmpty()) return null;
-
-        String[] tags = biomeTags.substring(1, biomeTags.length() - 1).split(",");
-        List<String> tagList = new ArrayList<>();
-
-        for (String tag : tags) {
-            tagList.add(tag.trim());
-        }
-
-        return tagList.toArray(new String[0]);
     }
 }

--- a/src/main/java/cybercat5555/faunus/common/config/SpawnHandler.java
+++ b/src/main/java/cybercat5555/faunus/common/config/SpawnHandler.java
@@ -1,8 +1,8 @@
 package cybercat5555.faunus.common.config;
 
+import cybercat5555.faunus.common.tags.FaunusBiomeTags;
 import cybercat5555.faunus.core.EntityRegistry;
 import cybercat5555.faunus.core.entity.livingEntity.*;
-import cybercat5555.faunus.util.MCUtil;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectionContext;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
@@ -45,10 +45,10 @@ public class SpawnHandler {
 
     public static void addSpawn() {
         /* ARAPAIMA */
-        Predicate<BiomeSelectionContext> arapaimaSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(ARAPAIMA_BIOME_TAG));
+        Predicate<BiomeSelectionContext> arapaimaSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_ARAPAIMA);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(ARAPAIMA_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : arapaimaSpawnPredicate,
+                arapaimaSpawnPredicate,
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.ARAPAIMA,
                 ARAPAIMA_SPAWN_WEIGHT, ARAPAIMA_SPAWN_MIN_GROUP, ARAPAIMA_SPAWN_MAX_GROUP
@@ -61,10 +61,10 @@ public class SpawnHandler {
                 ArapaimaEntity::canMobSpawn);
 
         /* CAPUCHIN */
-        Predicate<BiomeSelectionContext> capuchinSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(CAPUCHIN_BIOME_TAG));
+        Predicate<BiomeSelectionContext> capuchinSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CAPUCHIN);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(CAPUCHIN_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : capuchinSpawnPredicate,
+                capuchinSpawnPredicate,
                 SpawnGroup.AMBIENT,
                 EntityRegistry.CAPUCHIN,
                 CAPUCHIN_SPAWN_WEIGHT, CAPUCHIN_SPAWN_MIN_GROUP, CAPUCHIN_SPAWN_MAX_GROUP
@@ -77,10 +77,10 @@ public class SpawnHandler {
                 CapuchinEntity::canMobSpawn);
 
         /* CRAYFISH */
-        Predicate<BiomeSelectionContext> crayfishSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(CRAYFISH_BIOME_TAG));
+        Predicate<BiomeSelectionContext> crayfishSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CRAYFISH);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(CRAYFISH_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : crayfishSpawnPredicate,
+                crayfishSpawnPredicate,
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.CRAYFISH,
                 CRAYFISH_SPAWN_WEIGHT, CRAYFISH_SPAWN_MIN_GROUP, CRAYFISH_SPAWN_MAX_GROUP
@@ -93,10 +93,10 @@ public class SpawnHandler {
                 CrayfishEntity::canMobSpawn);
 
         /* HOATZIN */
-        Predicate<BiomeSelectionContext> hoatzinSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(HOATZIN_BIOME_TAG));
+        Predicate<BiomeSelectionContext> hoatzinSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_HOATZIN);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(HOATZIN_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : hoatzinSpawnPredicate,
+                hoatzinSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.HOATZIN,
                 HOATZIN_SPAWN_WEIGHT, HOATZIN_SPAWN_MIN_GROUP, HOATZIN_SPAWN_MAX_GROUP
@@ -109,10 +109,10 @@ public class SpawnHandler {
                 HoatzinEntity::canMobSpawn);
 
         /* LEECH */
-        Predicate<BiomeSelectionContext> leechSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(LEECH_BIOME_TAG));
+        Predicate<BiomeSelectionContext> leechSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_LEECH);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(LEECH_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : leechSpawnPredicate,
+                leechSpawnPredicate,
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.LEECH,
                 LEECH_SPAWN_WEIGHT, LEECH_SPAWN_MIN_GROUP, LEECH_SPAWN_MAX_GROUP
@@ -125,10 +125,10 @@ public class SpawnHandler {
                 LeechEntity::canMobSpawn);
 
         /* PIRANHA */
-        Predicate<BiomeSelectionContext> piranhaSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(PIRANHA_BIOME_TAG));
+        Predicate<BiomeSelectionContext> piranhaSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_PIRANHA);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(PIRANHA_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : piranhaSpawnPredicate,
+                piranhaSpawnPredicate,
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.PIRANHA,
                 PIRANHA_SPAWN_WEIGHT, PIRANHA_SPAWN_MIN_GROUP, PIRANHA_SPAWN_MAX_GROUP
@@ -141,10 +141,10 @@ public class SpawnHandler {
                 PiranhaEntity::canMobSpawn);
 
         /* QUETZAL */
-        Predicate<BiomeSelectionContext> quetzalSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(QUETZAL_BIOME_TAG));
+        Predicate<BiomeSelectionContext> quetzalSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_QUETZAL);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(QUETZAL_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : quetzalSpawnPredicate,
+                quetzalSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.QUETZAL,
                 QUETZAL_SPAWN_WEIGHT, QUETZAL_SPAWN_MIN_GROUP, QUETZAL_SPAWN_MAX_GROUP
@@ -157,10 +157,10 @@ public class SpawnHandler {
                 QuetzalEntity::canMobSpawn);
 
         /* SNAPPING_TURTLE */
-        Predicate<BiomeSelectionContext> snappingTurtleSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(SNAPPING_TURTLE_BIOME_TAG));
+        Predicate<BiomeSelectionContext> snappingTurtleSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SNAPPING_TURTLE);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(SNAPPING_TURTLE_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : snappingTurtleSpawnPredicate,
+                snappingTurtleSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.SNAPPING_TURTLE,
                 SNAPPING_TURTLE_SPAWN_WEIGHT, SNAPPING_TURTLE_SPAWN_MIN_GROUP, SNAPPING_TURTLE_SPAWN_MAX_GROUP
@@ -173,10 +173,10 @@ public class SpawnHandler {
                 SnappingTurtleEntity::canMobSpawn);
 
         /* SONGBIRD */
-        Predicate<BiomeSelectionContext> songbirdSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(SONGBIRD_BIOME_TAG));
+        Predicate<BiomeSelectionContext> songbirdSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SONGBIRD);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(SONGBIRD_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : songbirdSpawnPredicate,
+                songbirdSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.SONGBIRD,
                 SONGBIRD_SPAWN_WEIGHT, SONGBIRD_SPAWN_MIN_GROUP, SONGBIRD_SPAWN_MAX_GROUP
@@ -189,10 +189,10 @@ public class SpawnHandler {
                 SongbirdEntity::canMobSpawn);
 
         /* TAPIR */
-        Predicate<BiomeSelectionContext> tapirSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(TAPIR_BIOME_TAG));
+        Predicate<BiomeSelectionContext> tapirSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_TAPIR);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(TAPIR_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : tapirSpawnPredicate,
+                tapirSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.TAPIR,
                 TAPIR_SPAWN_WEIGHT, TAPIR_SPAWN_MIN_GROUP, TAPIR_SPAWN_MAX_GROUP
@@ -205,10 +205,10 @@ public class SpawnHandler {
                 TapirEntity::canMobSpawn);
 
         /* YACARE */
-        Predicate<BiomeSelectionContext> yacareSpawnPredicate = BiomeSelectors.includeByKey(MCUtil.getBiomeKeys(YACARE_BIOME_TAG));
+        Predicate<BiomeSelectionContext> yacareSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_YACARE);
 
         BiomeModifications.addSpawn(
-                MCUtil.getBiomeKeys(YACARE_BIOME_TAG).isEmpty() ? BiomeSelectors.all() : yacareSpawnPredicate,
+                yacareSpawnPredicate,
                 SpawnGroup.CREATURE,
                 EntityRegistry.YACARE,
                 YACARE_SPAWN_WEIGHT, YACARE_SPAWN_MIN_GROUP, YACARE_SPAWN_MAX_GROUP

--- a/src/main/java/cybercat5555/faunus/common/tags/FaunusBiomeTags.java
+++ b/src/main/java/cybercat5555/faunus/common/tags/FaunusBiomeTags.java
@@ -1,0 +1,39 @@
+package cybercat5555.faunus.common.tags;
+
+import cybercat5555.faunus.Faunus;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.biome.Biome;
+
+public class FaunusBiomeTags {
+    public static final TagKey<Biome> SPAWNS_ARAPAIMA = FaunusBiomeTags.of("spawns_arapaima");
+    public static final TagKey<Biome> SPAWNS_CAPUCHIN = FaunusBiomeTags.of("spawns_capuchin");
+    public static final TagKey<Biome> SPAWNS_CONSTRICTOR = FaunusBiomeTags.of("spawns_constrictor");
+    public static final TagKey<Biome> SPAWNS_CRAYFISH = FaunusBiomeTags.of("spawns_crayfish");
+    public static final TagKey<Biome> SPAWNS_HOATZIN = FaunusBiomeTags.of("spawns_hoatzin");
+    public static final TagKey<Biome> SPAWNS_LEECH = FaunusBiomeTags.of("spawns_leech");
+    public static final TagKey<Biome> SPAWNS_PIRANHA = FaunusBiomeTags.of("spawns_piranha");
+    public static final TagKey<Biome> SPAWNS_QUETZAL = FaunusBiomeTags.of("spawns_quetzal");
+    public static final TagKey<Biome> SPAWNS_SNAPPING_TURTLE = FaunusBiomeTags.of("spawns_snapping_turtle");
+    public static final TagKey<Biome> SPAWNS_SONGBIRD = FaunusBiomeTags.of("spawns_songbird");
+    public static final TagKey<Biome> SPAWNS_TAPIR = FaunusBiomeTags.of("spawns_tapir");
+    public static final TagKey<Biome> SPAWNS_TARANTULA = FaunusBiomeTags.of("spawns_tarantula");
+    public static final TagKey<Biome> SPAWNS_YACARE = FaunusBiomeTags.of("spawns_yacare");
+    public static final TagKey<Biome> SPAWNS_YACARE_MANEATER = FaunusBiomeTags.of("spawns_yacare_maneater");
+
+    public static final TagKey<Biome> IS_SWAMP = FaunusBiomeTags.of(Identifier.of("c", "is_swamp"));
+
+    @SuppressWarnings("UnnecessaryReturnStatement")
+    private FaunusBiomeTags() {
+        return;
+    }
+
+    private static TagKey<Biome> of(String path) {
+        return FaunusBiomeTags.of(Identifier.of(Faunus.MODID, path));
+    }
+
+    private static TagKey<Biome> of(Identifier id) {
+        return TagKey.of(RegistryKeys.BIOME, id);
+    }
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_arapaima.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_arapaima.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_river",
+    "#c:is_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_capuchin.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_capuchin.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_constrictor.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_constrictor.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_crayfish.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_crayfish.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#c:is_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_hoatzin.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_hoatzin.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "minecraft:mangrove_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_leech.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_leech.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#c:is_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_piranha.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_piranha.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "minecraft:mangrove_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_quetzal.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_quetzal.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_snapping_turtle.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_snapping_turtle.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_songbird.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_songbird.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle",
+    "#c:is_swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_tapir.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_tapir.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_jungle"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_tarantula.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_tarantula.json
@@ -1,0 +1,5 @@
+{
+  "replace": false,
+  "values": [
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_yacare.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_yacare.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:swamp"
+  ]
+}

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_yacare_maneater.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_yacare_maneater.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:swamp"
+  ]
+}


### PR DESCRIPTION
This PR does two things:

- Use biome tags for entity spawning
- Remove farm animals from `minecraft:is_jungle`

With the former, I'm mostly just hoping to start a conversation about finding a way to use vanilla and conventional biome tags to achieve better compatibility with biome mods.  Both types of biome tag have seen a lot of improvements over the past year or so, and now conventional tags are largely standardized between fabric/quilt and neoforge.  Biome modders have been encouraged to use more biome tags, and even if all Faunus did for biome mod compatibility was to use biome tags, I think the compatibility would be pretty good.  This also allows biome mods to further refine compatibility with Faunus by modifying the Faunus spawn tags.

I don't know how important it is having the biomes in the configuration; I have taken the easy road of removing that functionality, but another (more technically difficult) path might be to allow tags in the configuration instead.  For example, this PR makes Faunus compatible with the Terraformers biome mods (Traverse and Terrestria in the overworld).

As for the latter change, all it does is turn on the existing functionality to remove the mods from biomes tagged `minecraft:is_jungle`.  I did this because when we discussed in Discord it sounded like having it turned off might have been an oversight.  It does appear to work, although passive spawns are slow, so it is hard to really confirm.  I think this feature is best left turned off unless biome tags are also being used for mob additions (as in this PR).
