### PR TITLE
Revise spawn conditions to be more similar to vanilla's.  Fix minor bugs.

### DIFF
--- a/src/main/java/cybercat5555/faunus/common/config/MobSpawningConfig.java
+++ b/src/main/java/cybercat5555/faunus/common/config/MobSpawningConfig.java
@@ -57,47 +57,47 @@ public class MobSpawningConfig {
         configRegistry.addPairData(new Pair<>("constrictor_spawn_max_group", 3), "Constrictor spawn max group");
 
         configRegistry.addComment("Crayfish");
-        configRegistry.addPairData(new Pair<>("crayfish_spawn_weight", 5), "Crayfish spawn weight");
+        configRegistry.addPairData(new Pair<>("crayfish_spawn_weight", 15), "Crayfish spawn weight");
         configRegistry.addPairData(new Pair<>("crayfish_spawn_min_group", 1), "Crayfish spawn min group");
         configRegistry.addPairData(new Pair<>("crayfish_spawn_max_group", 3), "Crayfish spawn max group");
 
         configRegistry.addComment("Hoatzin");
-        configRegistry.addPairData(new Pair<>("hoatzin_spawn_weight", 5), "Hoatzin spawn weight");
+        configRegistry.addPairData(new Pair<>("hoatzin_spawn_weight", 25), "Hoatzin spawn weight");
         configRegistry.addPairData(new Pair<>("hoatzin_spawn_min_group", 1), "Hoatzin spawn min group");
         configRegistry.addPairData(new Pair<>("hoatzin_spawn_max_group", 3), "Hoatzin spawn max group");
 
         configRegistry.addComment("Iguana");
-        configRegistry.addPairData(new Pair<>("iguana_spawn_weight", 5), "Iguana spawn weight");
+        configRegistry.addPairData(new Pair<>("iguana_spawn_weight", 25), "Iguana spawn weight");
         configRegistry.addPairData(new Pair<>("iguana_spawn_min_group", 1), "Iguana spawn min group");
         configRegistry.addPairData(new Pair<>("iguana_spawn_max_group", 3), "Iguana spawn max group");
 
         configRegistry.addComment("Leech");
-        configRegistry.addPairData(new Pair<>("leech_spawn_weight", 5), "Leech spawn weight");
+        configRegistry.addPairData(new Pair<>("leech_spawn_weight", 15), "Leech spawn weight");
         configRegistry.addPairData(new Pair<>("leech_spawn_min_group", 1), "Leech spawn min group");
         configRegistry.addPairData(new Pair<>("leech_spawn_max_group", 3), "Leech spawn max group");
 
         configRegistry.addComment("Piranha");
-        configRegistry.addPairData(new Pair<>("piranha_spawn_weight", 5), "Piranha spawn weight");
+        configRegistry.addPairData(new Pair<>("piranha_spawn_weight", 10), "Piranha spawn weight");
         configRegistry.addPairData(new Pair<>("piranha_spawn_min_group", 1), "Piranha spawn min group");
         configRegistry.addPairData(new Pair<>("piranha_spawn_max_group", 3), "Piranha spawn max group");
 
         configRegistry.addComment("Quetzal");
-        configRegistry.addPairData(new Pair<>("quetzal_spawn_weight", 5), "Quetzal spawn weight");
+        configRegistry.addPairData(new Pair<>("quetzal_spawn_weight", 25), "Quetzal spawn weight");
         configRegistry.addPairData(new Pair<>("quetzal_spawn_min_group", 1), "Quetzal spawn min group");
         configRegistry.addPairData(new Pair<>("quetzal_spawn_max_group", 3), "Quetzal spawn max group");
 
         configRegistry.addComment("Snapping Turtle");
-        configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_weight", 5), "Snapping Turtle spawn weight");
+        configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_weight", 15), "Snapping Turtle spawn weight");
         configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_min_group", 1), "Snapping Turtle spawn min group");
         configRegistry.addPairData(new Pair<>("snapping_turtle_spawn_max_group", 3), "Snapping Turtle spawn max group");
 
         configRegistry.addComment("Songbird");
-        configRegistry.addPairData(new Pair<>("songbird_spawn_weight", 5), "Songbird spawn weight");
+        configRegistry.addPairData(new Pair<>("songbird_spawn_weight", 25), "Songbird spawn weight");
         configRegistry.addPairData(new Pair<>("songbird_spawn_min_group", 1), "Songbird spawn min group");
         configRegistry.addPairData(new Pair<>("songbird_spawn_max_group", 3), "Songbird spawn max group");
 
         configRegistry.addComment("Tapir");
-        configRegistry.addPairData(new Pair<>("tapir_spawn_weight", 5), "Tapir spawn weight");
+        configRegistry.addPairData(new Pair<>("tapir_spawn_weight", 10), "Tapir spawn weight");
         configRegistry.addPairData(new Pair<>("tapir_spawn_min_group", 1), "Tapir spawn min group");
         configRegistry.addPairData(new Pair<>("tapir_spawn_max_group", 3), "Tapir spawn max group");
 
@@ -107,7 +107,7 @@ public class MobSpawningConfig {
         configRegistry.addPairData(new Pair<>("tarantula_spawn_max_group", 3), "Tarantula spawn max group");
 
         configRegistry.addComment("Yacare");
-        configRegistry.addPairData(new Pair<>("yacare_spawn_weight", 5), "Yacare spawn weight");
+        configRegistry.addPairData(new Pair<>("yacare_spawn_weight", 10), "Yacare spawn weight");
         configRegistry.addPairData(new Pair<>("yacare_spawn_min_group", 1), "Yacare spawn min group");
         configRegistry.addPairData(new Pair<>("yacare_spawn_max_group", 3), "Yacare spawn max group");
 

--- a/src/main/java/cybercat5555/faunus/common/config/SpawnHandler.java
+++ b/src/main/java/cybercat5555/faunus/common/config/SpawnHandler.java
@@ -4,17 +4,15 @@ import cybercat5555.faunus.common.tags.FaunusBiomeTags;
 import cybercat5555.faunus.core.EntityRegistry;
 import cybercat5555.faunus.core.entity.livingEntity.*;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
-import net.fabricmc.fabric.api.biome.v1.BiomeSelectionContext;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.biome.v1.ModificationPhase;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnGroup;
 import net.minecraft.entity.SpawnRestriction;
+import net.minecraft.entity.passive.AnimalEntity;
 import net.minecraft.registry.tag.BiomeTags;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.Heightmap;
-
-import java.util.function.Predicate;
 
 import static cybercat5555.faunus.common.config.MobSpawningConfig.*;
 
@@ -45,10 +43,8 @@ public class SpawnHandler {
 
     public static void addSpawn() {
         /* ARAPAIMA */
-        Predicate<BiomeSelectionContext> arapaimaSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_ARAPAIMA);
-
         BiomeModifications.addSpawn(
-                arapaimaSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_ARAPAIMA),
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.ARAPAIMA,
                 ARAPAIMA_SPAWN_WEIGHT, ARAPAIMA_SPAWN_MIN_GROUP, ARAPAIMA_SPAWN_MAX_GROUP
@@ -61,10 +57,8 @@ public class SpawnHandler {
                 ArapaimaEntity::canMobSpawn);
 
         /* CAPUCHIN */
-        Predicate<BiomeSelectionContext> capuchinSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CAPUCHIN);
-
         BiomeModifications.addSpawn(
-                capuchinSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CAPUCHIN),
                 SpawnGroup.AMBIENT,
                 EntityRegistry.CAPUCHIN,
                 CAPUCHIN_SPAWN_WEIGHT, CAPUCHIN_SPAWN_MIN_GROUP, CAPUCHIN_SPAWN_MAX_GROUP
@@ -73,14 +67,12 @@ public class SpawnHandler {
         SpawnRestriction.register(
                 EntityRegistry.CAPUCHIN,
                 SpawnRestriction.Location.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                CapuchinEntity::canMobSpawn);
+                Heightmap.Type.MOTION_BLOCKING,
+                CapuchinEntity::canSpawn);
 
         /* CRAYFISH */
-        Predicate<BiomeSelectionContext> crayfishSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CRAYFISH);
-
         BiomeModifications.addSpawn(
-                crayfishSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_CRAYFISH),
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.CRAYFISH,
                 CRAYFISH_SPAWN_WEIGHT, CRAYFISH_SPAWN_MIN_GROUP, CRAYFISH_SPAWN_MAX_GROUP
@@ -90,13 +82,11 @@ public class SpawnHandler {
                 EntityRegistry.CRAYFISH,
                 SpawnRestriction.Location.IN_WATER,
                 Heightmap.Type.OCEAN_FLOOR,
-                CrayfishEntity::canMobSpawn);
+                CrayfishEntity::canSpawn);
 
         /* HOATZIN */
-        Predicate<BiomeSelectionContext> hoatzinSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_HOATZIN);
-
         BiomeModifications.addSpawn(
-                hoatzinSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_HOATZIN),
                 SpawnGroup.CREATURE,
                 EntityRegistry.HOATZIN,
                 HOATZIN_SPAWN_WEIGHT, HOATZIN_SPAWN_MIN_GROUP, HOATZIN_SPAWN_MAX_GROUP
@@ -105,8 +95,8 @@ public class SpawnHandler {
         SpawnRestriction.register(
                 EntityRegistry.HOATZIN,
                 SpawnRestriction.Location.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                HoatzinEntity::canMobSpawn);
+                Heightmap.Type.MOTION_BLOCKING,
+                HoatzinEntity::canSpawnHoatzin);
 
         /* IGUANA */
         BiomeModifications.addSpawn(
@@ -120,13 +110,11 @@ public class SpawnHandler {
                 EntityRegistry.IGUANA,
                 SpawnRestriction.Location.ON_GROUND,
                 Heightmap.Type.MOTION_BLOCKING,
-                IguanaEntity::canMobSpawn);
+                IguanaEntity::canSpawn);
 
         /* LEECH */
-        Predicate<BiomeSelectionContext> leechSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_LEECH);
-
         BiomeModifications.addSpawn(
-                leechSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_LEECH),
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.LEECH,
                 LEECH_SPAWN_WEIGHT, LEECH_SPAWN_MIN_GROUP, LEECH_SPAWN_MAX_GROUP
@@ -136,13 +124,11 @@ public class SpawnHandler {
                 EntityRegistry.LEECH,
                 SpawnRestriction.Location.IN_WATER,
                 Heightmap.Type.OCEAN_FLOOR,
-                LeechEntity::canMobSpawn);
+                LeechEntity::canSpawn);
 
         /* PIRANHA */
-        Predicate<BiomeSelectionContext> piranhaSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_PIRANHA);
-
         BiomeModifications.addSpawn(
-                piranhaSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_PIRANHA),
                 SpawnGroup.WATER_CREATURE,
                 EntityRegistry.PIRANHA,
                 PIRANHA_SPAWN_WEIGHT, PIRANHA_SPAWN_MIN_GROUP, PIRANHA_SPAWN_MAX_GROUP
@@ -152,13 +138,11 @@ public class SpawnHandler {
                 EntityRegistry.PIRANHA,
                 SpawnRestriction.Location.IN_WATER,
                 Heightmap.Type.OCEAN_FLOOR,
-                PiranhaEntity::canMobSpawn);
+                PiranhaEntity::canSpawn);
 
         /* QUETZAL */
-        Predicate<BiomeSelectionContext> quetzalSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_QUETZAL);
-
         BiomeModifications.addSpawn(
-                quetzalSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_QUETZAL),
                 SpawnGroup.CREATURE,
                 EntityRegistry.QUETZAL,
                 QUETZAL_SPAWN_WEIGHT, QUETZAL_SPAWN_MIN_GROUP, QUETZAL_SPAWN_MAX_GROUP
@@ -167,14 +151,12 @@ public class SpawnHandler {
         SpawnRestriction.register(
                 EntityRegistry.QUETZAL,
                 SpawnRestriction.Location.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                QuetzalEntity::canMobSpawn);
+                Heightmap.Type.MOTION_BLOCKING,
+                QuetzalEntity::canSpawnQuetzal);
 
         /* SNAPPING_TURTLE */
-        Predicate<BiomeSelectionContext> snappingTurtleSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SNAPPING_TURTLE);
-
         BiomeModifications.addSpawn(
-                snappingTurtleSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SNAPPING_TURTLE),
                 SpawnGroup.CREATURE,
                 EntityRegistry.SNAPPING_TURTLE,
                 SNAPPING_TURTLE_SPAWN_WEIGHT, SNAPPING_TURTLE_SPAWN_MIN_GROUP, SNAPPING_TURTLE_SPAWN_MAX_GROUP
@@ -184,13 +166,11 @@ public class SpawnHandler {
                 EntityRegistry.SNAPPING_TURTLE,
                 SpawnRestriction.Location.ON_GROUND,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                SnappingTurtleEntity::canMobSpawn);
+                SnappingTurtleEntity::canSpawn);
 
         /* SONGBIRD */
-        Predicate<BiomeSelectionContext> songbirdSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SONGBIRD);
-
         BiomeModifications.addSpawn(
-                songbirdSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_SONGBIRD),
                 SpawnGroup.CREATURE,
                 EntityRegistry.SONGBIRD,
                 SONGBIRD_SPAWN_WEIGHT, SONGBIRD_SPAWN_MIN_GROUP, SONGBIRD_SPAWN_MAX_GROUP
@@ -199,14 +179,12 @@ public class SpawnHandler {
         SpawnRestriction.register(
                 EntityRegistry.SONGBIRD,
                 SpawnRestriction.Location.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                SongbirdEntity::canMobSpawn);
+                Heightmap.Type.MOTION_BLOCKING,
+                SongbirdEntity::canSpawnSongbird);
 
         /* TAPIR */
-        Predicate<BiomeSelectionContext> tapirSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_TAPIR);
-
         BiomeModifications.addSpawn(
-                tapirSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_TAPIR),
                 SpawnGroup.CREATURE,
                 EntityRegistry.TAPIR,
                 TAPIR_SPAWN_WEIGHT, TAPIR_SPAWN_MIN_GROUP, TAPIR_SPAWN_MAX_GROUP
@@ -216,13 +194,11 @@ public class SpawnHandler {
                 EntityRegistry.TAPIR,
                 SpawnRestriction.Location.ON_GROUND,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                TapirEntity::canMobSpawn);
+                AnimalEntity::isValidNaturalSpawn);
 
         /* YACARE */
-        Predicate<BiomeSelectionContext> yacareSpawnPredicate = BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_YACARE);
-
         BiomeModifications.addSpawn(
-                yacareSpawnPredicate,
+                BiomeSelectors.tag(FaunusBiomeTags.SPAWNS_YACARE),
                 SpawnGroup.CREATURE,
                 EntityRegistry.YACARE,
                 YACARE_SPAWN_WEIGHT, YACARE_SPAWN_MIN_GROUP, YACARE_SPAWN_MAX_GROUP
@@ -232,6 +208,6 @@ public class SpawnHandler {
                 EntityRegistry.YACARE,
                 SpawnRestriction.Location.ON_GROUND,
                 Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                YacareEntity::canMobSpawn);
+                YacareEntity::canSpawnYacare);
     }
 }

--- a/src/main/java/cybercat5555/faunus/common/tags/FaunusBiomeTags.java
+++ b/src/main/java/cybercat5555/faunus/common/tags/FaunusBiomeTags.java
@@ -23,7 +23,8 @@ public class FaunusBiomeTags {
     public static final TagKey<Biome> SPAWNS_YACARE = FaunusBiomeTags.of("spawns_yacare");
     public static final TagKey<Biome> SPAWNS_YACARE_MANEATER = FaunusBiomeTags.of("spawns_yacare_maneater");
 
-    public static final TagKey<Biome> IS_SWAMP = FaunusBiomeTags.of(Identifier.of("c", "is_swamp"));
+    // TODO: changes to c:is_swamp in 1.21
+    public static final TagKey<Biome> SWAMP = FaunusBiomeTags.of(Identifier.of("c", "swamp"));
 
     @SuppressWarnings("UnnecessaryReturnStatement")
     private FaunusBiomeTags() {

--- a/src/main/java/cybercat5555/faunus/core/entity/control/move/FlightWalkMoveControl.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/control/move/FlightWalkMoveControl.java
@@ -25,6 +25,7 @@ public class FlightWalkMoveControl extends MoveControl {
     public FlightWalkMoveControl(MobEntity entity, int maxPitchChange, boolean noGravity) {
         super(entity);
         this.noGravity = noGravity;
+        this.type = MoveType.WALK;
     }
 
     public void changeMovementType(MoveType type) {

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/CapuchinEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/CapuchinEntity.java
@@ -6,8 +6,10 @@ import cybercat5555.faunus.core.entity.FeedableEntity;
 import cybercat5555.faunus.core.entity.ai.goals.HangTreeGoal;
 import cybercat5555.faunus.core.entity.projectile.CocoaBeanProjectile;
 import cybercat5555.faunus.util.FaunusID;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -21,6 +23,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvent;
@@ -28,8 +31,11 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.EntityView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.WorldView;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
@@ -85,8 +91,6 @@ public class CapuchinEntity extends TameableShoulderEntity implements GeoEntity,
         this.goalSelector.add(4, new FollowOwnerGoal(this, 1.0, 5.0f, 1.0f, true));
 
         targetSelector.add(1, new RevengeGoal(this));
-        targetSelector.add(2, new ActiveTargetGoal<>(this, LivingEntity.class, true,
-                target -> target instanceof CapuchinEntity || target instanceof PlayerEntity));
     }
 
     @Override
@@ -149,6 +153,26 @@ public class CapuchinEntity extends TameableShoulderEntity implements GeoEntity,
         }
 
         return PlayState.STOP;
+    }
+
+    public static boolean canSpawn(EntityType<CapuchinEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return world.getBlockState(pos.down()).isIn(BlockTags.PARROTS_SPAWNABLE_ON);
+    }
+
+    public boolean canSpawn(WorldView world) {
+        if (world.doesNotIntersectEntities(this) && !world.containsFluid(this.getBoundingBox())) {
+            BlockPos blockPos = this.getBlockPos();
+            if (blockPos.getY() < world.getSeaLevel()) {
+                return false;
+            }
+
+            BlockState blockState = world.getBlockState(blockPos.down());
+            return  blockState.isIn(BlockTags.ANIMALS_SPAWNABLE_ON) ||
+                    blockState.isIn(BlockTags.LEAVES) ||
+                    blockState.isIn(BlockTags.LOGS);
+        }
+
+        return false;
     }
 
     @Nullable

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/CrayfishEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/CrayfishEntity.java
@@ -31,9 +31,9 @@ import net.minecraft.registry.tag.TagKey;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
-import net.minecraft.world.LocalDifficulty;
-import net.minecraft.world.ServerWorldAccess;
-import net.minecraft.world.World;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.*;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
@@ -113,6 +113,15 @@ public class CrayfishEntity extends AnimalEntity implements GeoEntity, FeedableE
         }
 
         return PlayState.CONTINUE;
+    }
+
+    public static boolean canSpawn(EntityType<CrayfishEntity> type, WorldAccess world, SpawnReason reason, BlockPos pos, Random random) {
+        return pos.getY() >= world.getSeaLevel() - 13;
+    }
+
+    @Override
+    public boolean canSpawn(WorldView world) {
+        return world.doesNotIntersectEntities(this);
     }
 
     @Override

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/HoatzinEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/HoatzinEntity.java
@@ -6,6 +6,7 @@ import cybercat5555.faunus.core.entity.control.move.FlightWalkMoveControl;
 import cybercat5555.faunus.core.entity.control.move.MoveType;
 import cybercat5555.faunus.util.FaunusID;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.brain.MemoryModuleType;
 import net.minecraft.entity.ai.brain.sensor.Sensor;
 import net.minecraft.entity.ai.brain.sensor.SensorType;
@@ -18,12 +19,16 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.EntityView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.core.animation.AnimatableManager.ControllerRegistrar;
@@ -35,7 +40,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 public class HoatzinEntity extends ParrotEntity implements GeoEntity, FeedableEntity {
     protected static final ImmutableList<SensorType<? extends Sensor<? super GoatEntity>>> SENSORS = ImmutableList.of(SensorType.NEAREST_LIVING_ENTITIES, SensorType.NEAREST_PLAYERS, SensorType.NEAREST_ITEMS, SensorType.NEAREST_ADULT, SensorType.HURT_BY, SensorType.GOAT_TEMPTATIONS);
-    protected static final ImmutableList<MemoryModuleType<?>> MEMORY_MODULES = ImmutableList.of(MemoryModuleType.LOOK_TARGET, MemoryModuleType.VISIBLE_MOBS, MemoryModuleType.WALK_TARGET, MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE, MemoryModuleType.PATH, MemoryModuleType.ATE_RECENTLY, MemoryModuleType.BREED_TARGET, MemoryModuleType.LONG_JUMP_COOLING_DOWN, MemoryModuleType.LONG_JUMP_MID_JUMP, MemoryModuleType.TEMPTING_PLAYER, MemoryModuleType.NEAREST_VISIBLE_ADULT, MemoryModuleType.TEMPTATION_COOLDOWN_TICKS, new MemoryModuleType[]{MemoryModuleType.IS_TEMPTED, MemoryModuleType.RAM_COOLDOWN_TICKS, MemoryModuleType.RAM_TARGET, MemoryModuleType.IS_PANICKING});
+    protected static final ImmutableList<MemoryModuleType<?>> MEMORY_MODULES = ImmutableList.of(MemoryModuleType.LOOK_TARGET, MemoryModuleType.VISIBLE_MOBS, MemoryModuleType.WALK_TARGET, MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE, MemoryModuleType.PATH, MemoryModuleType.ATE_RECENTLY, MemoryModuleType.BREED_TARGET, MemoryModuleType.LONG_JUMP_COOLING_DOWN, MemoryModuleType.LONG_JUMP_MID_JUMP, MemoryModuleType.TEMPTING_PLAYER, MemoryModuleType.NEAREST_VISIBLE_ADULT, MemoryModuleType.TEMPTATION_COOLDOWN_TICKS, MemoryModuleType.IS_TEMPTED, MemoryModuleType.RAM_COOLDOWN_TICKS, MemoryModuleType.RAM_TARGET, MemoryModuleType.IS_PANICKING);
 
 
     protected static final RawAnimation IDLE_ANIM = RawAnimation.begin().thenLoop("idle");
@@ -98,6 +103,10 @@ public class HoatzinEntity extends ParrotEntity implements GeoEntity, FeedableEn
     @Override
     protected void addFlapEffects() {
         this.playSound(SoundEvents.ENTITY_PARROT_FLY, 0.075f, 1.0f);
+    }
+
+    public static boolean canSpawnHoatzin(EntityType<HoatzinEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return world.getBlockState(pos.down()).isIn(BlockTags.PARROTS_SPAWNABLE_ON) && isLightLevelValidForNaturalSpawn(world, pos);
     }
 
     @Override

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/IguanaEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/IguanaEntity.java
@@ -3,7 +3,9 @@ package cybercat5555.faunus.core.entity.livingEntity;
 import cybercat5555.faunus.core.ItemRegistry;
 import cybercat5555.faunus.core.entity.FeedableEntity;
 import cybercat5555.faunus.util.FaunusID;
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.control.AquaticMoveControl;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
@@ -18,11 +20,16 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.registry.tag.TagKey;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.WorldView;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.GeoAnimatable;
@@ -158,6 +165,27 @@ public class IguanaEntity extends AnimalEntity implements GeoEntity, FeedableEnt
         return PlayState.CONTINUE;
     }
 
+
+    public static boolean canSpawn(EntityType<IguanaEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return true;
+    }
+
+    @Override
+    public boolean canSpawn(WorldView world) {
+        if (world.doesNotIntersectEntities(this) && !world.containsFluid(this.getBoundingBox())) {
+            BlockPos blockPos = this.getBlockPos();
+            if (blockPos.getY() < world.getSeaLevel()) {
+                return false;
+            }
+
+            BlockState blockState = world.getBlockState(blockPos.down());
+            return  blockState.isIn(BlockTags.ANIMALS_SPAWNABLE_ON) ||
+                    blockState.isIn(BlockTags.LEAVES) ||
+                    blockState.isIn(BlockTags.LOGS);
+        }
+
+        return false;
+    }
 
     @Override
     public boolean cannotDespawn() {

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/LeechEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/LeechEntity.java
@@ -7,6 +7,7 @@ import cybercat5555.faunus.util.FaunusID;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -25,7 +26,10 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.WorldView;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.GeoAnimatable;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
@@ -130,6 +134,15 @@ public class LeechEntity extends PathAwareEntity implements GeoEntity, FeedableE
         }
 
         return PlayState.CONTINUE;
+    }
+
+    public static boolean canSpawn(EntityType<LeechEntity> type, WorldAccess world, SpawnReason reason, BlockPos pos, Random random) {
+        return pos.getY() >= world.getSeaLevel() - 13;
+    }
+
+    @Override
+    public boolean canSpawn(WorldView world) {
+        return world.doesNotIntersectEntities(this);
     }
 
     @Override

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/QuetzalEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/QuetzalEntity.java
@@ -3,16 +3,21 @@ package cybercat5555.faunus.core.entity.livingEntity;
 import cybercat5555.faunus.core.EntityRegistry;
 import cybercat5555.faunus.core.SoundRegistry;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.ParrotEntity;
 import net.minecraft.entity.passive.PassiveEntity;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.EntityView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
@@ -60,6 +65,10 @@ public class QuetzalEntity extends ParrotEntity implements GeoEntity {
     @Override
     public void registerControllers(ControllerRegistrar controllers) {
         controllers.add(new AnimationController<>(this, "idle", 10, this::idleAnimController));
+    }
+
+    public static boolean canSpawnQuetzal(EntityType<QuetzalEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return world.getBlockState(pos.down()).isIn(BlockTags.PARROTS_SPAWNABLE_ON) && isLightLevelValidForNaturalSpawn(world, pos);
     }
 
     @Override

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/SnappingTurtleEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/SnappingTurtleEntity.java
@@ -5,6 +5,7 @@ import cybercat5555.faunus.core.entity.ai.goals.TerritorialSelectorGoal;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.control.AquaticMoveControl;
 import net.minecraft.entity.ai.goal.MeleeAttackGoal;
 import net.minecraft.entity.ai.goal.RevengeGoal;
@@ -16,7 +17,11 @@ import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.PathAwareEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.BlockRenderView;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import software.bernie.geckolib.animatable.GeoEntity;
 import software.bernie.geckolib.core.animatable.GeoAnimatable;
 import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache;
@@ -99,6 +104,14 @@ public class SnappingTurtleEntity extends PathAwareEntity implements GeoEntity {
         }
 
         return PlayState.CONTINUE;
+    }
+
+    public static boolean canSpawn(EntityType<SnappingTurtleEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return pos.getY() < world.getSeaLevel() + 4 && SnappingTurtleEntity.isLightLevelValidForNaturalSpawn(world, pos);
+    }
+
+    protected static boolean isLightLevelValidForNaturalSpawn(BlockRenderView world, BlockPos pos) {
+        return world.getBaseLightLevel(pos, 0) > 8;
     }
 
     static class SnappingTurtleAttack extends MeleeAttackGoal {

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/SongbirdEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/SongbirdEntity.java
@@ -19,13 +19,13 @@ import net.minecraft.entity.passive.PassiveEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.registry.tag.BiomeTags;
+import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
-import net.minecraft.world.EntityView;
-import net.minecraft.world.LocalDifficulty;
-import net.minecraft.world.ServerWorldAccess;
-import net.minecraft.world.World;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
+import net.minecraft.world.*;
 import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.animatable.GeoEntity;
@@ -120,6 +120,10 @@ public class SongbirdEntity extends ParrotEntity implements GeoEntity {
         }
 
         return PlayState.CONTINUE;
+    }
+
+    public static boolean canSpawnSongbird(EntityType<SongbirdEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return world.getBlockState(pos.down()).isIn(BlockTags.PARROTS_SPAWNABLE_ON) && isLightLevelValidForNaturalSpawn(world, pos);
     }
 
     @Override

--- a/src/main/java/cybercat5555/faunus/core/entity/livingEntity/YacareEntity.java
+++ b/src/main/java/cybercat5555/faunus/core/entity/livingEntity/YacareEntity.java
@@ -13,6 +13,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.ai.goal.ActiveTargetGoal;
 import net.minecraft.entity.ai.goal.AnimalMateGoal;
 import net.minecraft.entity.ai.goal.MoveToTargetPosGoal;
@@ -45,6 +46,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
 import net.minecraft.world.WorldView;
 import net.minecraft.world.event.GameEvent;
 import org.jetbrains.annotations.Nullable;
@@ -103,6 +105,10 @@ public class YacareEntity extends TurtleEntity implements GeoEntity, FeedableEnt
                         (target instanceof WaterCreatureEntity && target.getBoundingBox().getAverageSideLength() < getBoundingBox().getAverageSideLength())
                                 || target instanceof IguanaEntity || target instanceof CrayfishEntity));
 
+    }
+
+    public static boolean canSpawnYacare(EntityType<YacareEntity> type, WorldAccess world, SpawnReason spawnReason, BlockPos pos, Random random) {
+        return pos.getY() < world.getSeaLevel() + 4 && isLightLevelValidForNaturalSpawn(world, pos);
     }
 
     @Override

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_arapaima.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_arapaima.json
@@ -2,6 +2,6 @@
   "replace": false,
   "values": [
     "#minecraft:is_river",
-    "#c:is_swamp"
+    "#c:swamp"
   ]
 }

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_crayfish.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_crayfish.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#c:is_swamp"
+    "#c:swamp"
   ]
 }

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_iguana.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_iguana.json
@@ -2,6 +2,6 @@
   "replace": false,
   "values": [
     "#minecraft:is_jungle",
-    "#c:is_swamp"
+    "#c:swamp"
   ]
 }

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_leech.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_leech.json
@@ -1,6 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#c:is_swamp"
+    "#c:swamp"
   ]
 }

--- a/src/main/resources/data/faunus/tags/worldgen/biome/spawns_songbird.json
+++ b/src/main/resources/data/faunus/tags/worldgen/biome/spawns_songbird.json
@@ -2,6 +2,6 @@
   "replace": false,
   "values": [
     "#minecraft:is_jungle",
-    "#c:is_swamp"
+    "#c:swamp"
   ]
 }


### PR DESCRIPTION
This PR is mainly about trying to get spawns to work more consistently.  Previously, most of the animals used vanilla's `MobEntity.canMobSpawn()` method, which vanilla itself only uses for special mobs like Iron Golem and Ender Dragon.  I've added custom methods to the individual animals which require spawn conditions tailored to that particular animal.  For example, birds can spawn on leaves, yacare should spawn near sea level, etc.

There are also a few minor bug fixes, including removing the random target goal from Capuchin so it will only target for revenge.  Perhaps this second goal was originally added to make testing the throw attack easier.

This PR does not address the fact Capuchins spawn rather often in Sparse Jungle and less often in Jungle, which I understand is the opposite of the desired result.  One way this issue might potentially be addressed would be to add a second spawn configuration with a higher spawn rate just for the Jungle biome itself.

I have specifically attempted to restrain myself from making unnecessary code quality improvements.

- Avoid using MobEntity.canMobSpawn() which is rarely used by vanilla
- Review spawning conditions and rates and attempt to improve them
- Use `c:swamp` in 1.20; `c:is_swamp` was not widely used yet (should change back in 1.21)
- Prevent Capuchins from randomly targeting Capuchins and Players
- Fix a rare crash in FlightWalkMoveControl